### PR TITLE
Snapshot status andaction disabling

### DIFF
--- a/language/en_us/vultr.php
+++ b/language/en_us/vultr.php
@@ -61,6 +61,7 @@ $lang['Vultr.service_field.enable_ipv6'] = 'Enable IPv6';
 $lang['Vultr.service_field.disable_ipv6'] = 'Disable IPv6';
 
 // Service management
+$lang['Vultr.tab_actions.server_locked'] = 'A snapshot is currently being restored. This process can take up to 60 minutes to complete. Most server actions will be unavailable until this has completed.';
 $lang['Vultr.tab_actions.status_title'] = 'Server Status';
 $lang['Vultr.tab_actions.server_title'] = 'Server Actions';
 $lang['Vultr.tab_actions.action_restart'] = 'Restart';
@@ -93,6 +94,7 @@ $lang['Vultr.tab_stats.app_information'] = 'Application Information';
 $lang['Vultr.tab_snapshots.snapshots'] = 'Snapshots';
 $lang['Vultr.tab_snapshots.heading_row_snapshot_id'] = 'Snapshot ID';
 $lang['Vultr.tab_snapshots.heading_row_description'] = 'Description';
+$lang['Vultr.tab_snapshots.heading_row_status'] = 'Status';
 $lang['Vultr.tab_snapshots.heading_row_options'] = 'Options';
 $lang['Vultr.tab_snapshots.restore_snapshot'] = 'Restore Snapshot';
 $lang['Vultr.tab_snapshots.remove_snapshot'] = 'Remove Snapshot';
@@ -114,6 +116,7 @@ $lang['Vultr.tab_backups.backups_disabled'] = 'This server does not have automat
 $lang['Vultr.tab_client_actions.heading_status'] = 'Server Status';
 $lang['Vultr.tab_client_actions.status_online'] = 'Online';
 $lang['Vultr.tab_client_actions.status_offline'] = 'Offline';
+$lang['Vultr.tab_client_actions.status_locked'] = 'Locked';
 
 $lang['Vultr.tab_client_actions.heading_actions'] = 'Actions';
 $lang['Vultr.tab_client_actions.action_restart'] = 'Restart';
@@ -150,6 +153,7 @@ $lang['Vultr.tab_client_stats.app_information'] = 'Application Information';
 $lang['Vultr.tab_client_snapshots.snapshots'] = 'Snapshots';
 $lang['Vultr.tab_client_snapshots.snapshot_id'] = 'Snapshot ID';
 $lang['Vultr.tab_client_snapshots.description'] = 'Description';
+$lang['Vultr.tab_client_snapshots.status'] = 'Status';
 $lang['Vultr.tab_client_snapshots.options'] = 'Options';
 $lang['Vultr.tab_client_snapshots.heading_restore_snapshot'] = 'Restore Snapshot %1$s'; // %1$s is the snapshot id
 $lang['Vultr.tab_client_snapshots.heading_remove_snapshot'] = 'Remove Snapshot %1$s'; // %1$s is the snapshot id
@@ -197,6 +201,7 @@ $lang['Vultr.!error.meta[baremetal_plan].format'] = 'Please select a valid Bare 
 $lang['Vultr.!error.meta[server_plan].format'] = 'Please select a valid Server Plan.';
 
 $lang['Vultr.!error.api.internal'] = 'An internal error occurred, or the server did not respond to the request.';
+$lang['Vultr.!error.api.server_locked'] = 'Unable to complete action.  Server is currently locked.';
 $lang['Vultr.!error.module_row.missing'] = 'An internal error occurred. The module row is unavailable.';
 
 $lang['Vultr.!error.vultr_hostname.format'] = 'Please enter a valid hostname, e.g. domain.com.';

--- a/views/default/tab_actions.pdt
+++ b/views/default/tab_actions.pdt
@@ -4,7 +4,10 @@
     </div>
     <div class="pad">
         <?php
-        if ($this->Html->ifSet($server_details->power_status) == 'running' || $this->Html->ifSet($server_details->status) == 'active') {
+        if($this->Html->ifSet($server_details->server_state) == 'locked') {
+            $status_class = 'warning';
+            $status = 'locked';
+        } elseif ($this->Html->ifSet($server_details->power_status) == 'running' || $this->Html->ifSet($server_details->status) == 'active') {
             $status_class = 'success';
             $status = 'online';
         } else {
@@ -39,7 +42,7 @@
                 $this->Form->create();
                 $this->Form->fieldHidden('action', 'reinstall');
                 ?>
-                <button class="btn btn-default btn-block" style="margin-top: 10px;">
+                <button<?php echo $this->Html->ifSet($status) == 'locked' ? ' disabled="disabled"' : '';?> class="btn btn-default btn-block" style="margin-top: 10px;">
                     <i class="fa fa-refresh"></i> <?php $this->_('Vultr.tab_client_actions.action_reinstall_template'); ?>
                 </button>
                 <?php
@@ -58,7 +61,7 @@
                 $this->Form->end();
                 ?>
 
-                <a href="#" class="change_template btn btn-default btn-block<?php echo $this->Html->ifSet($package->meta->set_template) != 'client' ? ' disabled' : ''; ?>" style="margin-top: 10px; float: left; padding: 6px 0px;">
+                <a href="#" class="change_template btn btn-default btn-block<?php echo $this->Html->ifSet($package->meta->set_template) != 'client' || $this->Html->ifSet($status) == 'locked' ? ' disabled' : ''; ?>" style="margin-top: 10px; float: left; padding: 6px 0px;">
                     <i class="fa fa-download"></i> <?php $this->_('Vultr.tab_client_actions.action_change_template'); ?>
                 </a>
             </div>
@@ -77,7 +80,7 @@
                 <?php
                 $this->Form->create($this->Html->ifSet($server_details->kvm_url), ['target' => '_blank']);
                 ?>
-                <button class="btn btn-default btn-block" style="margin-top: 10px;">
+                <button<?php echo $this->Html->ifSet($status) == 'locked' ? ' disabled="disabled"' : '';?> class="btn btn-default btn-block" style="margin-top: 10px;">
                     <i class="fa fa-terminal"></i> <?php $this->_('Vultr.tab_actions.action_kvm_console'); ?>
                 </button>
                 <?php

--- a/views/default/tab_actions.pdt
+++ b/views/default/tab_actions.pdt
@@ -4,7 +4,7 @@
     </div>
     <div class="pad">
         <?php
-        if($this->Html->ifSet($server_details->server_state) == 'locked') {
+        if ($this->Html->ifSet($server_details->server_state) == 'locked') {
             $status_class = 'warning';
             $status = 'locked';
         } elseif ($this->Html->ifSet($server_details->power_status) == 'running' || $this->Html->ifSet($server_details->status) == 'active') {

--- a/views/default/tab_client_actions.pdt
+++ b/views/default/tab_client_actions.pdt
@@ -1,7 +1,10 @@
     <h4><?php $this->_('Vultr.tab_client_actions.heading_status'); ?></h4>
 
     <?php
-    if ($this->Html->ifSet($server_details->power_status) == 'running' || $this->Html->ifSet($server_details->status) == 'active') {
+    if($this->Html->ifSet($server_details->server_state) == 'locked') {
+        $status_class = 'warning';
+        $status = 'locked';
+    } elseif ($this->Html->ifSet($server_details->power_status) == 'running' || $this->Html->ifSet($server_details->status) == 'active') {
         $status_class = 'success';
         $status = 'online';
     } else {
@@ -32,7 +35,7 @@
             $this->Form->create();
             $this->Form->fieldHidden('action', 'reinstall');
             ?>
-            <button class="btn btn-default btn-block" style="margin-top: 10px;">
+            <button<?php echo $this->Html->ifSet($status) == 'locked' ? ' disabled="disabled"' : '';?> class="btn btn-default btn-block" style="margin-top: 10px;">
                 <i class="fa fa-refresh"></i> <?php $this->_('Vultr.tab_client_actions.action_reinstall_template'); ?>
             </button>
             <?php
@@ -51,7 +54,7 @@
             $this->Form->end();
             ?>
 
-            <a href="#" class="change_template btn btn-default btn-block<?php echo $this->Html->ifSet($package->meta->set_template) != 'client' ? ' disabled' : ''; ?>" style="margin-top: 10px;">
+            <a href="#" class="change_template btn btn-default btn-block<?php echo $this->Html->ifSet($package->meta->set_template) != 'client' || $this->Html->ifSet($status) == 'locked' ? ' disabled' : ''; ?>" style="margin-top: 10px;">
                 <i class="fa fa-download"></i> <?php $this->_('Vultr.tab_client_actions.action_change_template'); ?>
             </a>
         </div>
@@ -67,7 +70,7 @@
             $this->Form->end();
             ?>
 
-            <a href="<?php echo $this->Html->ifSet($server_details->kvm_url); ?>" class="btn btn-default btn-block<?php echo empty($this->Html->ifSet($server_details->kvm_url)) ? ' disabled' : ''; ?>" target="_blank" style="margin-top: 10px;">
+            <a href="<?php echo $this->Html->ifSet($server_details->kvm_url); ?>" class="btn btn-default btn-block<?php echo empty($this->Html->ifSet($server_details->kvm_url)) || $this->Html->ifSet($status) == 'locked' ? ' disabled' : ''; ?>" target="_blank" style="margin-top: 10px;">
                 <i class="fa fa-terminal"></i> <?php $this->_('Vultr.tab_client_actions.action_kvm_console'); ?>
             </a>
         </div>

--- a/views/default/tab_client_actions.pdt
+++ b/views/default/tab_client_actions.pdt
@@ -1,7 +1,7 @@
     <h4><?php $this->_('Vultr.tab_client_actions.heading_status'); ?></h4>
 
     <?php
-    if($this->Html->ifSet($server_details->server_state) == 'locked') {
+    if ($this->Html->ifSet($server_details->server_state) == 'locked') {
         $status_class = 'warning';
         $status = 'locked';
     } elseif ($this->Html->ifSet($server_details->power_status) == 'running' || $this->Html->ifSet($server_details->status) == 'active') {

--- a/views/default/tab_client_snapshots.pdt
+++ b/views/default/tab_client_snapshots.pdt
@@ -26,16 +26,16 @@
                     <td><?php $this->Html->_($snapshot->description); ?></td>
                     <td><?php echo ucwords($this->Html->safe($snapshot->status)); ?></td>
                     <td>
-                        <a class="btn btn-xs btn-success restore-snapshot" href="#" data-id="<?php $this->Html->_($snapshot->SNAPSHOTID); ?>" data-toggle="modal" data-target="#restore-snapshot<?php echo $snapshot->SNAPSHOTID; ?>">
+                        <a class="btn btn-xs btn-success restore-snapshot" href="#" data-id="<?php $this->Html->_($snapshot->SNAPSHOTID); ?>" data-toggle="modal" data-target="#restore-snapshot<?php $this->Html->_($snapshot->SNAPSHOTID); ?>">
                             <i class="fa fa-check"></i>
                             <?php $this->_('Vultr.tab_client_snapshots.restore_snapshot'); ?>
                         </a>
-                        <div id="restore-snapshot<?php echo $snapshot->SNAPSHOTID; ?>" class="modal fade" tabindex="-1" role="dialog" aria-hidden="true">
+                        <div id="restore-snapshot<?php $this->Html->_($snapshot->SNAPSHOTID); ?>" class="modal fade" tabindex="-1" role="dialog" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
                                     <div class="modal-header">
                                         <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
-                                        <h4 class="global_modal_title"><?php $this->_('Vultr.tab_client_snapshots.heading_restore_snapshot', false, $this->Html->ifSet($snapshot->SNAPSHOTID)); ?></h4>
+                                        <h4 class="global_modal_title"><?php $this->_('Vultr.tab_client_snapshots.heading_restore_snapshot', false, $this->Html->_($snapshot->SNAPSHOTID, true)); ?></h4>
                                     </div>
                                     <div class="modal-body"><?php $this->_('Vultr.tab_client_snapshots.confirm_restore_snapshot'); ?></div>
                                     <div class="modal-footer">
@@ -48,16 +48,16 @@
                             </div>
                         </div>
 
-                        <a class="btn btn-xs btn-danger remove-snapshot" href="#" data-id="<?php $this->Html->_($snapshot->SNAPSHOTID); ?>" data-toggle="modal" data-target="#remove-snapshot<?php echo $snapshot->SNAPSHOTID; ?>">
+                        <a class="btn btn-xs btn-danger remove-snapshot" href="#" data-id="<?php $this->Html->_($snapshot->SNAPSHOTID); ?>" data-toggle="modal" data-target="#remove-snapshot<?php $this->Html->_($snapshot->SNAPSHOTID); ?>">
                             <i class="fa fa-ban fa-fw"></i>
                             <?php $this->_('Vultr.tab_client_snapshots.remove_snapshot'); ?>
                         </a>
-                        <div id="remove-snapshot<?php echo $snapshot->SNAPSHOTID; ?>" class="modal fade" tabindex="-1" role="dialog" aria-hidden="true">
+                        <div id="remove-snapshot<?php $this->Html->_($snapshot->SNAPSHOTID); ?>" class="modal fade" tabindex="-1" role="dialog" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
                                     <div class="modal-header">
                                         <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
-                                        <h4 class="global_modal_title"><?php $this->_('Vultr.tab_client_snapshots.heading_remove_snapshot', false, $this->Html->ifSet($snapshot->SNAPSHOTID)); ?></h4>
+                                        <h4 class="global_modal_title"><?php $this->_('Vultr.tab_client_snapshots.heading_remove_snapshot', false, $this->Html->_($snapshot->SNAPSHOTID, true)); ?></h4>
                                     </div>
                                     <div class="modal-body"><?php $this->_('Vultr.tab_client_snapshots.confirm_remove_snapshot'); ?></div>
                                     <div class="modal-footer">

--- a/views/default/tab_client_snapshots.pdt
+++ b/views/default/tab_client_snapshots.pdt
@@ -13,27 +13,29 @@
                 <tr>
                     <th><?php $this->_('Vultr.tab_client_snapshots.snapshot_id'); ?></th>
                     <th><?php $this->_('Vultr.tab_client_snapshots.description'); ?></th>
+                    <th><?php $this->_('Vultr.tab_client_snapshots.status'); ?></th>
                     <th><?php $this->_('Vultr.tab_client_snapshots.options'); ?></th>
                 </tr>
             </thead>
             <tbody>
                 <?php
-                foreach ($snapshots as $snapshotid => $description) {
+                foreach ($snapshots as $snapshot) {
                 ?>
                 <tr>
-                    <td><strong><?php $this->Html->_($snapshotid); ?></strong></td>
-                    <td><?php $this->Html->_($description); ?></td>
+                    <td><strong><?php $this->Html->_($snapshot->SNAPSHOTID); ?></strong></td>
+                    <td><?php $this->Html->_($snapshot->description); ?></td>
+                    <td><?php echo ucwords($this->Html->safe($snapshot->status)); ?></td>
                     <td>
-                        <a class="btn btn-xs btn-success restore-snapshot" href="#" data-id="<?php $this->Html->_($snapshotid); ?>" data-toggle="modal" data-target="#restore-snapshot<?php echo $snapshotid; ?>">
+                        <a class="btn btn-xs btn-success restore-snapshot" href="#" data-id="<?php $this->Html->_($snapshot->SNAPSHOTID); ?>" data-toggle="modal" data-target="#restore-snapshot<?php echo $snapshot->SNAPSHOTID; ?>">
                             <i class="fa fa-check"></i>
                             <?php $this->_('Vultr.tab_client_snapshots.restore_snapshot'); ?>
                         </a>
-                        <div id="restore-snapshot<?php echo $snapshotid; ?>" class="modal fade" tabindex="-1" role="dialog" aria-hidden="true">
+                        <div id="restore-snapshot<?php echo $snapshot->SNAPSHOTID; ?>" class="modal fade" tabindex="-1" role="dialog" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
                                     <div class="modal-header">
                                         <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
-                                        <h4 class="global_modal_title"><?php $this->_('Vultr.tab_client_snapshots.heading_restore_snapshot', false, $this->Html->ifSet($snapshotid)); ?></h4>
+                                        <h4 class="global_modal_title"><?php $this->_('Vultr.tab_client_snapshots.heading_restore_snapshot', false, $this->Html->ifSet($snapshot->SNAPSHOTID)); ?></h4>
                                     </div>
                                     <div class="modal-body"><?php $this->_('Vultr.tab_client_snapshots.confirm_restore_snapshot'); ?></div>
                                     <div class="modal-footer">
@@ -46,16 +48,16 @@
                             </div>
                         </div>
 
-                        <a class="btn btn-xs btn-danger remove-snapshot" href="#" data-id="<?php $this->Html->_($snapshotid); ?>" data-toggle="modal" data-target="#remove-snapshot<?php echo $snapshotid; ?>">
+                        <a class="btn btn-xs btn-danger remove-snapshot" href="#" data-id="<?php $this->Html->_($snapshot->SNAPSHOTID); ?>" data-toggle="modal" data-target="#remove-snapshot<?php echo $snapshot->SNAPSHOTID; ?>">
                             <i class="fa fa-ban fa-fw"></i>
                             <?php $this->_('Vultr.tab_client_snapshots.remove_snapshot'); ?>
                         </a>
-                        <div id="remove-snapshot<?php echo $snapshotid; ?>" class="modal fade" tabindex="-1" role="dialog" aria-hidden="true">
+                        <div id="remove-snapshot<?php echo $snapshot->SNAPSHOTID; ?>" class="modal fade" tabindex="-1" role="dialog" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
                                     <div class="modal-header">
                                         <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
-                                        <h4 class="global_modal_title"><?php $this->_('Vultr.tab_client_snapshots.heading_remove_snapshot', false, $this->Html->ifSet($snapshotid)); ?></h4>
+                                        <h4 class="global_modal_title"><?php $this->_('Vultr.tab_client_snapshots.heading_remove_snapshot', false, $this->Html->ifSet($snapshot->SNAPSHOTID)); ?></h4>
                                     </div>
                                     <div class="modal-body"><?php $this->_('Vultr.tab_client_snapshots.confirm_remove_snapshot'); ?></div>
                                     <div class="modal-footer">
@@ -80,13 +82,11 @@
             $('a.restore-snapshot').on('click', function() {
                 $('#snapshotid').val($(this).attr('data-id'));
                 $('#action').val('restore');
-                $($(this).attr('data-target')).modal('show');
             });
 
             $('a.remove-snapshot').on('click', function() {
                 $('#snapshotid').val($(this).attr('data-id'));
                 $('#action').val('remove');
-                $($(this).attr('data-target')).modal('show');
             });
         });
     </script>

--- a/views/default/tab_snapshots.pdt
+++ b/views/default/tab_snapshots.pdt
@@ -13,21 +13,23 @@
                 <tr class="heading_row">
                     <td><span><?php $this->_('Vultr.tab_snapshots.heading_row_snapshot_id'); ?></span></td>
                     <td><span><?php $this->_('Vultr.tab_snapshots.heading_row_description'); ?></span></td>
+                    <td><span><?php $this->_('Vultr.tab_snapshots.heading_row_status'); ?></span></td>
                     <td class="last"><span><?php $this->_('Vultr.tab_snapshots.heading_row_options'); ?></span></td>
                 </tr>
                 <?php
                 $i = 0;
-                foreach ($snapshots as $snapshotid => $description) {
+                foreach ($snapshots as $snapshot) {
                 ?>
                 <tr<?php echo ($i % 2 == 1) ? ' class="odd_row"' : ''; ?>>
-                    <td><strong><?php $this->Html->_($snapshotid); ?></strong></td>
-                    <td><?php $this->Html->_($description); ?></td>
+                    <td><strong><?php $this->Html->_($snapshot->SNAPSHOTID); ?></strong></td>
+                    <td><?php $this->Html->_($snapshot->description); ?></td>
+                    <td><?php echo ucwords($this->Html->safe($snapshot->status)); ?></td>
                     <td>
-                        <a class="restore-snapshot submit" href="#" data-id="<?php $this->Html->_($snapshotid); ?>">
+                        <a class="restore-snapshot submit restore-snapshot" href="#" data-id="<?php $this->Html->_($snapshot->SNAPSHOTID); ?>">
                             <?php $this->_('Vultr.tab_snapshots.restore_snapshot'); ?>
                         </a>,
 
-                        <a class="manage submit" href="#" data-id="<?php $this->Html->_($snapshotid); ?>">
+                        <a class="manage submit remove-snapshot" href="#" data-id="<?php $this->Html->_($snapshot->SNAPSHOTID); ?>">
                             <?php $this->_('Vultr.tab_snapshots.remove_snapshot'); ?>
                         </a>
                     </td>

--- a/vultr.php
+++ b/vultr.php
@@ -1922,7 +1922,7 @@ class Vultr extends Module
     public function tabClientActions($package, $service, array $get = null, array $post = null, array $files = null)
     {
         // Get the actions tab
-        return $this->getTabActions($package, $service, $post, 'tab_client_actions');
+        return $this->getTabActions($package, $service, $post, true);
     }
 
     /**
@@ -2004,7 +2004,7 @@ class Vultr extends Module
     public function tabClientSnapshots($package, $service, array $get = null, array $post = null, array $files = null)
     {
         // Get snapshots tab
-        return $this->getTabSnapshots($package, $service, $post, 'tab_client_snapshots');
+        return $this->getTabSnapshots($package, $service, $post, true);
     }
 
     /**
@@ -2090,16 +2090,16 @@ class Vultr extends Module
      * @param stdClass $package A stdClass object representing the current package
      * @param stdClass $service A stdClass object representing the current service
      * @param array $post Any POST parameters
-     * @param string $template_name The name of the template to us
+     * @param bool $client Whether to use the client view template
      * @return string The string representing the contents of this tab
      */
-    private function getTabActions($package, $service, array $post = null, $template_name = 'tab_actions')
+    private function getTabActions($package, $service, array $post = null, $client = false)
     {
         // Get module row
         $row = $this->getModuleRow();
 
         // Set the current view
-        $this->view = new View($template_name, 'default');
+        $this->view = new View($client ? 'tab_client_actions' : 'tab_actions', 'default');
         $this->view->base_uri = $this->base_uri;
 
         // Load the helpers required for this view
@@ -2221,16 +2221,16 @@ class Vultr extends Module
      * @param stdClass $package A stdClass object representing the current package
      * @param stdClass $service A stdClass object representing the current service
      * @param array $post Any POST parameters
-     * @param string $template_name The name of the template to us
+     * @param bool $client Whether to use the client view template
      * @return string The string representing the contents of this tab
      */
-    private function getTabSnapshots($package, $service, array $post = null, $template_name = 'tab_snapshots')
+    private function getTabSnapshots($package, $service, array $post = null, $client = false)
     {
         // Get module row
         $row = $this->getModuleRow();
 
         // Set the current view
-        $this->view = new View($template_name, 'default');
+        $this->view = new View($client ? 'tab_client_snapshots' : 'tab_snapshots', 'default');
         $this->view->base_uri = $this->base_uri;
 
         // Load the helpers required for this view

--- a/vultr.php
+++ b/vultr.php
@@ -1389,6 +1389,15 @@ class Vultr extends Module
             }
 
             // Enable automatic backup
+            Loader::loadHelpers($this, ['Form']);
+            $enable_backup = null;
+            foreach ($service->options as $service_option) {
+                if ($service_option->option_name == 'enable_backup') {
+                    $enable_backup = $service_option;
+                    break;
+                }
+            }
+            $service_options = $this->Form->collapseObjectArray($service->options, 'option_value', 'option_name');
             if (isset($vars['configoptions']['enable_backup']) && $vars['configoptions']['enable_backup'] == 'enable') {
                 // Only virtual machines supports automatic backups
                 if ($package->meta->server_type == 'server') {
@@ -1397,6 +1406,18 @@ class Vultr extends Module
                     ];
                     $this->log('api.vultr.com|backup_enable', serialize($params), 'input', true);
                     $this->parseResponse($vultr_api->backupEnable($params));
+                }
+            } elseif ($enable_backup
+                && $enable_backup->option_value == 'enable'
+                && (isset($vars['staff_id']) || $enable_backup->option_editable)
+            ) {
+                // Only virtual machines supports automatic backups
+                if ($package->meta->server_type == 'server') {
+                    $params = [
+                        'SUBID' => $service_fields->vultr_subid
+                    ];
+                    $this->log('api.vultr.com|backup_enable', serialize($params), 'input', true);
+                    $this->parseResponse($vultr_api->backupDisable($params));
                 }
             }
 

--- a/vultr.php
+++ b/vultr.php
@@ -1389,15 +1389,6 @@ class Vultr extends Module
             }
 
             // Enable automatic backup
-            Loader::loadHelpers($this, ['Form']);
-            $enable_backup = null;
-            foreach ($service->options as $service_option) {
-                if ($service_option->option_name == 'enable_backup') {
-                    $enable_backup = $service_option;
-                    break;
-                }
-            }
-            $service_options = $this->Form->collapseObjectArray($service->options, 'option_value', 'option_name');
             if (isset($vars['configoptions']['enable_backup']) && $vars['configoptions']['enable_backup'] == 'enable') {
                 // Only virtual machines supports automatic backups
                 if ($package->meta->server_type == 'server') {
@@ -1406,18 +1397,6 @@ class Vultr extends Module
                     ];
                     $this->log('api.vultr.com|backup_enable', serialize($params), 'input', true);
                     $this->parseResponse($vultr_api->backupEnable($params));
-                }
-            } elseif ($enable_backup
-                && $enable_backup->option_value == 'enable'
-                && (isset($vars['staff_id']) || $enable_backup->option_editable)
-            ) {
-                // Only virtual machines supports automatic backups
-                if ($package->meta->server_type == 'server') {
-                    $params = [
-                        'SUBID' => $service_fields->vultr_subid
-                    ];
-                    $this->log('api.vultr.com|backup_enable', serialize($params), 'input', true);
-                    $this->parseResponse($vultr_api->backupDisable($params));
                 }
             }
 

--- a/vultr.php
+++ b/vultr.php
@@ -1269,11 +1269,6 @@ class Vultr extends Module
                 'encrypted' => 0
             ],
             [
-                'key' => 'vultr_snapshots',
-                'value' => [],
-                'encrypted' => 0
-            ],
-            [
                 'key' => 'vultr_dns_domains',
                 'value' => [],
                 'encrypted' => 0
@@ -1326,7 +1321,9 @@ class Vultr extends Module
         }
 
         // Disallow capital letters in hostname
-        $vars['vultr_hostname'] = strtolower($vars['vultr_hostname']);
+        if (isset($vars['vultr_hostname'])) {
+            $vars['vultr_hostname'] = strtolower($vars['vultr_hostname']);
+        }
 
         // Check for fields that changed
         $delta = [];
@@ -1406,8 +1403,7 @@ class Vultr extends Module
         // Set fields to update locally
         $fields = [
             'vultr_subid',
-            'vultr_template',
-            'vultr_snapshots'
+            'vultr_template'
         ];
 
         foreach ($fields as $field) {
@@ -1744,105 +1740,8 @@ class Vultr extends Module
      */
     public function tabActions($package, $service, array $get = null, array $post = null, array $files = null)
     {
-        // Get module row
-        $row = $this->getModuleRow();
-
-        // Set the current view
-        $this->view = new View('tab_actions', 'default');
-        $this->view->base_uri = $this->base_uri;
-
-        // Load the helpers required for this view
-        Loader::loadHelpers($this, ['Form', 'Html']);
-
-        // Get the service fields
-        $service_fields = $this->serviceFieldsToObject($service->fields);
-
-        // Get the available templates
-        $templates = $this->getTemplates($row, $package, $service);
-
-        // Initialize the Vultr API
-        $api = $this->getApi($row->meta->api_key);
-
-        if ($package->meta->server_type == 'server') {
-            $api->loadCommand('vultr_server');
-            $vultr_api = new VultrServer($api);
-        } else {
-            $api->loadCommand('vultr_baremetal');
-            $vultr_api = new VultrBaremetal($api);
-        }
-
-        // Perform actions
-        if (!empty($post['action'])) {
-            switch ($post['action']) {
-                case 'restart':
-                    $params = [
-                        'SUBID' => $service_fields->vultr_subid
-                    ];
-                    $vultr_api->reboot($params);
-                    break;
-                case 'stop':
-                    $params = [
-                        'SUBID' => $service_fields->vultr_subid
-                    ];
-                    $vultr_api->halt($params);
-                    break;
-                case 'start':
-                    $params = [
-                        'SUBID' => $service_fields->vultr_subid
-                    ];
-                    $vultr_api->reboot($params);
-                    break;
-                case 'reinstall':
-                    $params = [
-                        'SUBID' => $service_fields->vultr_subid,
-                        'hostname' => $service_fields->vultr_hostname
-                    ];
-                    $vultr_api->reinstall($params);
-                    break;
-                case 'change_template':
-                    if ($package->meta->set_template == 'client') {
-                        Loader::loadModels($this, ['Services']);
-
-                        $data = [
-                            'vultr_subid' => $service_fields->vultr_subid,
-                            'vultr_template' => $this->Html->ifSet($post['template'])
-                        ];
-                        $this->Services->edit($service->id, $data);
-
-                        if ($this->Services->errors()) {
-                            $vars = (object) $post;
-                            $this->Input->setErrors($this->Services->errors());
-                        }
-                    }
-                    break;
-                default:
-                    break;
-            }
-        }
-
-        // Get the server details
-        $params = [
-            'SUBID' => $service_fields->vultr_subid
-        ];
-        $this->log('api.vultr.com|list', serialize($params), 'input', true);
-
-        if ($package->meta->server_type == 'server') {
-            $server_details = $this->parseResponse($vultr_api->listServers($params));
-        } else {
-            $server_details = $this->parseResponse($vultr_api->listBaremetal($params));
-        }
-
-        $this->view->set('module_row', $row);
-        $this->view->set('package', $package);
-        $this->view->set('service', $service);
-        $this->view->set('service_fields', $service_fields);
-        $this->view->set('templates', $templates);
-        $this->view->set('server_details', (isset($server_details) ? $server_details : new stdClass()));
-        $this->view->set('vars', (isset($vars) ? $vars : new stdClass()));
-
-        $this->view->setDefaultView('components' . DS . 'modules' . DS . 'vultr' . DS);
-
-        return $this->view->fetch();
+        // Get the actions tab
+        return $this->getTabActions($package, $service, $post);
     }
 
     /**
@@ -1923,104 +1822,8 @@ class Vultr extends Module
      */
     public function tabSnapshots($package, $service, array $get = null, array $post = null, array $files = null)
     {
-        // Get module row
-        $row = $this->getModuleRow();
-
-        // Set the current view
-        $this->view = new View('tab_snapshots', 'default');
-        $this->view->base_uri = $this->base_uri;
-
-        // Load the helpers required for this view
-        Loader::loadHelpers($this, ['Form', 'Html']);
-
-        // Get the service fields
-        $service_fields = $this->serviceFieldsToObject($service->fields);
-
-        // Initialize the Vultr API
-        $api = $this->getApi($row->meta->api_key);
-        $api->loadCommand('vultr_server');
-        $api->loadCommand('vultr_snapshot');
-
-        $server_api = new VultrServer($api);
-        $snapshot_api = new VultrSnapshot($api);
-
-        // Perform actions
-        if (!empty($post)) {
-            switch ($post['action']) {
-                case 'create':
-                    $params = [
-                        'SUBID' => $service_fields->vultr_subid,
-                        'description' => $this->Html->safe($post['description'])
-                    ];
-                    $result = $this->parseResponse($snapshot_api->create($params));
-
-                    if (isset($result->SNAPSHOTID)) {
-                        Loader::loadModels($this, ['Services']);
-
-                        $service_fields->vultr_snapshots = $service_fields->vultr_snapshots + [
-                            $result->SNAPSHOTID => $this->Html->safe($post['description'])
-                        ];
-
-                        $data = [
-                            'vultr_snapshots' => $service_fields->vultr_snapshots
-                        ];
-                        $this->Services->edit($service->id, $data);
-
-                        if ($this->Services->errors()) {
-                            $this->Input->setErrors($this->Services->errors());
-                        }
-                    }
-
-                    $vars = (object) $post;
-                    break;
-                case 'remove':
-                    $params = [
-                        'SNAPSHOTID' => $this->Html->safe($post['snapshotid'])
-                    ];
-                    $snapshot_api->destroy($params);
-
-                    Loader::loadModels($this, ['Services']);
-
-                    unset($service_fields->vultr_snapshots[$post['snapshotid']]);
-
-                    $data = [
-                        'vultr_snapshots' => $service_fields->vultr_snapshots
-                    ];
-                    $this->Services->edit($service->id, $data);
-
-                    if ($this->Services->errors()) {
-                        $this->Input->setErrors($this->Services->errors());
-                    }
-
-                    $vars = (object) $post;
-                    break;
-                case 'restore':
-                    $params = [
-                        'SUBID' => $service_fields->vultr_subid,
-                        'SNAPSHOTID' => $this->Html->safe($post['snapshotid'])
-                    ];
-                    $server_api->restoreSnapshot($params);
-
-                    $vars = (object) $post;
-                    break;
-                default:
-                    break;
-            }
-        }
-
-        // Get server snapshots
-        $snapshots = $service_fields->vultr_snapshots;
-
-        $this->view->set('module_row', $row);
-        $this->view->set('package', $package);
-        $this->view->set('service', $service);
-        $this->view->set('service_fields', $service_fields);
-        $this->view->set('snapshots', (isset($snapshots) ? $snapshots : []));
-        $this->view->set('vars', (isset($vars) ? $vars : new stdClass()));
-
-        $this->view->setDefaultView('components' . DS . 'modules' . DS . 'vultr' . DS);
-
-        return $this->view->fetch();
+        // Get snapshots tab
+        return $this->getTabSnapshots($package, $service, $post);
     }
 
     /**
@@ -2112,105 +1915,8 @@ class Vultr extends Module
      */
     public function tabClientActions($package, $service, array $get = null, array $post = null, array $files = null)
     {
-        // Get module row
-        $row = $this->getModuleRow();
-
-        // Set the current view
-        $this->view = new View('tab_client_actions', 'default');
-        $this->view->base_uri = $this->base_uri;
-
-        // Load the helpers required for this view
-        Loader::loadHelpers($this, ['Form', 'Html']);
-
-        // Get the service fields
-        $service_fields = $this->serviceFieldsToObject($service->fields);
-
-        // Get the available templates
-        $templates = $this->getTemplates($row, $package, $service);
-
-        // Initialize the Vultr API
-        $api = $this->getApi($row->meta->api_key);
-
-        if ($package->meta->server_type == 'server') {
-            $api->loadCommand('vultr_server');
-            $vultr_api = new VultrServer($api);
-        } else {
-            $api->loadCommand('vultr_baremetal');
-            $vultr_api = new VultrBaremetal($api);
-        }
-
-        // Perform actions
-        if (!empty($post['action'])) {
-            switch ($post['action']) {
-                case 'restart':
-                    $params = [
-                        'SUBID' => $service_fields->vultr_subid
-                    ];
-                    $vultr_api->reboot($params);
-                    break;
-                case 'stop':
-                    $params = [
-                        'SUBID' => $service_fields->vultr_subid
-                    ];
-                    $vultr_api->halt($params);
-                    break;
-                case 'start':
-                    $params = [
-                        'SUBID' => $service_fields->vultr_subid
-                    ];
-                    $vultr_api->reboot($params);
-                    break;
-                case 'reinstall':
-                    $params = [
-                        'SUBID' => $service_fields->vultr_subid,
-                        'hostname' => $service_fields->vultr_hostname
-                    ];
-                    $vultr_api->reinstall($params);
-                    break;
-                case 'change_template':
-                    if ($package->meta->set_template == 'client') {
-                        Loader::loadModels($this, ['Services']);
-
-                        $data = [
-                            'vultr_subid' => $service_fields->vultr_subid,
-                            'vultr_template' => $this->Html->ifSet($post['template'])
-                        ];
-                        $this->Services->edit($service->id, $data);
-
-                        if ($this->Services->errors()) {
-                            $vars = (object) $post;
-                            $this->Input->setErrors($this->Services->errors());
-                        }
-                    }
-                    break;
-                default:
-                    break;
-            }
-        }
-
-        // Get the server details
-        $params = [
-            'SUBID' => $service_fields->vultr_subid
-        ];
-        $this->log('api.vultr.com|list', serialize($params), 'input', true);
-
-        if ($package->meta->server_type == 'server') {
-            $server_details = $this->parseResponse($vultr_api->listServers($params));
-        } else {
-            $server_details = $this->parseResponse($vultr_api->listBaremetal($params));
-        }
-
-        $this->view->set('module_row', $row);
-        $this->view->set('package', $package);
-        $this->view->set('service', $service);
-        $this->view->set('service_fields', $service_fields);
-        $this->view->set('templates', $templates);
-        $this->view->set('server_details', (isset($server_details) ? $server_details : new stdClass()));
-        $this->view->set('vars', (isset($vars) ? $vars : new stdClass()));
-
-        $this->view->setDefaultView('components' . DS . 'modules' . DS . 'vultr' . DS);
-
-        return $this->view->fetch();
+        // Get the actions tab
+        return $this->getTabActions($package, $service, $post, 'tab_client_actions');
     }
 
     /**
@@ -2291,104 +1997,8 @@ class Vultr extends Module
      */
     public function tabClientSnapshots($package, $service, array $get = null, array $post = null, array $files = null)
     {
-        // Get module row
-        $row = $this->getModuleRow();
-
-        // Set the current view
-        $this->view = new View('tab_client_snapshots', 'default');
-        $this->view->base_uri = $this->base_uri;
-
-        // Load the helpers required for this view
-        Loader::loadHelpers($this, ['Form', 'Html']);
-
-        // Get the service fields
-        $service_fields = $this->serviceFieldsToObject($service->fields);
-
-        // Initialize the Vultr API
-        $api = $this->getApi($row->meta->api_key);
-        $api->loadCommand('vultr_server');
-        $api->loadCommand('vultr_snapshot');
-
-        $server_api = new VultrServer($api);
-        $snapshot_api = new VultrSnapshot($api);
-
-        // Perform actions
-        if (!empty($post)) {
-            switch ($post['action']) {
-                case 'create':
-                    $params = [
-                        'SUBID' => $service_fields->vultr_subid,
-                        'description' => $this->Html->safe($post['description'])
-                    ];
-                    $result = $this->parseResponse($snapshot_api->create($params));
-
-                    if (isset($result->SNAPSHOTID)) {
-                        Loader::loadModels($this, ['Services']);
-
-                        $service_fields->vultr_snapshots = $service_fields->vultr_snapshots + [
-                            $result->SNAPSHOTID => $this->Html->safe($post['description'])
-                        ];
-
-                        $data = [
-                            'vultr_snapshots' => $service_fields->vultr_snapshots
-                        ];
-                        $this->Services->edit($service->id, $data);
-
-                        if ($this->Services->errors()) {
-                            $this->Input->setErrors($this->Services->errors());
-                        }
-                    }
-
-                    $vars = (object) $post;
-                    break;
-                case 'remove':
-                    $params = [
-                        'SNAPSHOTID' => $this->Html->safe($post['snapshotid'])
-                    ];
-                    $snapshot_api->destroy($params);
-
-                    Loader::loadModels($this, ['Services']);
-
-                    unset($service_fields->vultr_snapshots[$post['snapshotid']]);
-
-                    $data = [
-                        'vultr_snapshots' => $service_fields->vultr_snapshots
-                    ];
-                    $this->Services->edit($service->id, $data);
-
-                    if ($this->Services->errors()) {
-                        $this->Input->setErrors($this->Services->errors());
-                    }
-
-                    $vars = (object) $post;
-                    break;
-                case 'restore':
-                    $params = [
-                        'SUBID' => $service_fields->vultr_subid,
-                        'SNAPSHOTID' => $this->Html->safe($post['snapshotid'])
-                    ];
-                    $server_api->restoreSnapshot($params);
-
-                    $vars = (object) $post;
-                    break;
-                default:
-                    break;
-            }
-        }
-
-        // Get server snapshots
-        $snapshots = $service_fields->vultr_snapshots;
-
-        $this->view->set('module_row', $row);
-        $this->view->set('package', $package);
-        $this->view->set('service', $service);
-        $this->view->set('service_fields', $service_fields);
-        $this->view->set('snapshots', (isset($snapshots) ? $snapshots : []));
-        $this->view->set('vars', (isset($vars) ? $vars : new stdClass()));
-
-        $this->view->setDefaultView('components' . DS . 'modules' . DS . 'vultr' . DS);
-
-        return $this->view->fetch();
+        // Get snapshots tab
+        return $this->getTabSnapshots($package, $service, $post, 'tab_client_snapshots');
     }
 
     /**
@@ -2461,6 +2071,218 @@ class Vultr extends Module
         $this->view->set('service_fields', $service_fields);
         $this->view->set('service_options', $service_options);
         $this->view->set('backups', $backups);
+        $this->view->set('vars', (isset($vars) ? $vars : new stdClass()));
+
+        $this->view->setDefaultView('components' . DS . 'modules' . DS . 'vultr' . DS);
+
+        return $this->view->fetch();
+    }
+
+    /**
+     * Actions (Admin or Client) tab.
+     *
+     * @param stdClass $package A stdClass object representing the current package
+     * @param stdClass $service A stdClass object representing the current service
+     * @param array $post Any POST parameters
+     * @param string $template_name The name of the template to us
+     * @return string The string representing the contents of this tab
+     */
+    private function getTabActions($package, $service, array $post = null, $template_name = 'tab_actions')
+    {
+        // Get module row
+        $row = $this->getModuleRow();
+
+        // Set the current view
+        $this->view = new View($template_name, 'default');
+        $this->view->base_uri = $this->base_uri;
+
+        // Load the helpers required for this view
+        Loader::loadHelpers($this, ['Form', 'Html']);
+
+        // Get the service fields
+        $service_fields = $this->serviceFieldsToObject($service->fields);
+
+        // Get the available templates
+        $templates = $this->getTemplates($row, $package, $service);
+
+        // Initialize the Vultr API
+        $api = $this->getApi($row->meta->api_key);
+
+        if ($package->meta->server_type == 'server') {
+            $api->loadCommand('vultr_server');
+            $vultr_api = new VultrServer($api);
+        } else {
+            $api->loadCommand('vultr_baremetal');
+            $vultr_api = new VultrBaremetal($api);
+        }
+
+        if ($package->meta->server_type == 'server') {
+            $server_details = $this->parseResponse($vultr_api->listServers(['SUBID' => $service_fields->vultr_subid]));
+        } else {
+            $server_details = $this->parseResponse(
+                $vultr_api->listBaremetal(['SUBID' => $service_fields->vultr_subid])
+            );
+        }
+
+        // Set a warning about an in progress snapshot
+        $server_locked = isset($server_details->server_state) && $server_details->server_state == 'locked';
+        if ($server_locked) {
+            $this->setMessage('notice', Language::_('Vultr.tab_actions.server_locked', true));
+        }
+
+        // Perform actions
+        if (!empty($post['action'])) {
+            if ($server_locked) {
+                // Return error saying that the server is locked
+                $this->Input->setErrors(['api' => ['error' => Language::_('Vultr.!error.api.server_locked', true)]]);
+            } else {
+                switch ($post['action']) {
+                    case 'restart':
+                        $params = [
+                            'SUBID' => $service_fields->vultr_subid
+                        ];
+                        $vultr_api->reboot($params);
+                        break;
+                    case 'stop':
+                        $params = [
+                            'SUBID' => $service_fields->vultr_subid
+                        ];
+                        $vultr_api->halt($params);
+                        break;
+                    case 'start':
+                        $params = [
+                            'SUBID' => $service_fields->vultr_subid
+                        ];
+                        $vultr_api->reboot($params);
+                        break;
+                    case 'reinstall':
+                        $params = [
+                            'SUBID' => $service_fields->vultr_subid,
+                            'hostname' => $service_fields->vultr_hostname
+                        ];
+                        $vultr_api->reinstall($params);
+                        break;
+                    case 'change_template':
+                        if ($package->meta->set_template == 'client') {
+                            Loader::loadModels($this, ['Services']);
+
+                            $data = [
+                                'vultr_subid' => $service_fields->vultr_subid,
+                                'vultr_template' => $this->Html->ifSet($post['template'])
+                            ];
+                            $this->Services->edit($service->id, $data);
+
+                            if ($this->Services->errors()) {
+                                $vars = (object) $post;
+                                $this->Input->setErrors($this->Services->errors());
+                            }
+                        }
+                        break;
+                    default:
+                        break;
+                }
+            }
+        }
+
+        // Get the server details
+        $params = [
+            'SUBID' => $service_fields->vultr_subid
+        ];
+        $this->log('api.vultr.com|list', serialize($params), 'input', true);
+
+        if ($package->meta->server_type == 'server') {
+            $server_details = $this->parseResponse($vultr_api->listServers($params));
+        } else {
+            $server_details = $this->parseResponse($vultr_api->listBaremetal($params));
+        }
+
+        $this->view->set('module_row', $row);
+        $this->view->set('package', $package);
+        $this->view->set('service', $service);
+        $this->view->set('service_fields', $service_fields);
+        $this->view->set('templates', $templates);
+        $this->view->set('server_details', (isset($server_details) ? $server_details : new stdClass()));
+        $this->view->set('vars', (isset($vars) ? $vars : new stdClass()));
+
+        $this->view->setDefaultView('components' . DS . 'modules' . DS . 'vultr' . DS);
+
+        return $this->view->fetch();
+    }
+
+    /**
+     * Snapshots (Admin or Client) tab.
+     *
+     * @param stdClass $package A stdClass object representing the current package
+     * @param stdClass $service A stdClass object representing the current service
+     * @param array $post Any POST parameters
+     * @param string $template_name The name of the template to us
+     * @return string The string representing the contents of this tab
+     */
+    private function getTabSnapshots($package, $service, array $post = null, $template_name = 'tab_snapshots')
+    {
+        // Get module row
+        $row = $this->getModuleRow();
+
+        // Set the current view
+        $this->view = new View($template_name, 'default');
+        $this->view->base_uri = $this->base_uri;
+
+        // Load the helpers required for this view
+        Loader::loadHelpers($this, ['Form', 'Html']);
+
+        // Get the service fields
+        $service_fields = $this->serviceFieldsToObject($service->fields);
+
+        // Initialize the Vultr API
+        $api = $this->getApi($row->meta->api_key);
+        $api->loadCommand('vultr_server');
+        $api->loadCommand('vultr_snapshot');
+
+        $server_api = new VultrServer($api);
+        $snapshot_api = new VultrSnapshot($api);
+
+        // Perform actions
+        if (!empty($post)) {
+            switch ($post['action']) {
+                case 'create':
+                    $params = [
+                        'SUBID' => $service_fields->vultr_subid,
+                        'description' => $this->Html->safe($post['description'])
+                    ];
+                    $this->parseResponse($snapshot_api->create($params));
+
+                    $vars = (object) $post;
+                    break;
+                case 'remove':
+                    $params = [
+                        'SNAPSHOTID' => $this->Html->safe($post['snapshotid'])
+                    ];
+                    $this->parseResponse($snapshot_api->destroy($params));
+
+                    $vars = (object) $post;
+                    break;
+                case 'restore':
+                    $params = [
+                        'SUBID' => $service_fields->vultr_subid,
+                        'SNAPSHOTID' => $this->Html->safe($post['snapshotid'])
+                    ];
+                    $server_api->restoreSnapshot($params);
+
+                    $vars = (object) $post;
+                    break;
+                default:
+                    break;
+            }
+        }
+
+        // Get server snapshots
+        $snapshots = $this->parseResponse($snapshot_api->listSnapshots());
+
+        $this->view->set('module_row', $row);
+        $this->view->set('package', $package);
+        $this->view->set('service', $service);
+        $this->view->set('service_fields', $service_fields);
+        $this->view->set('snapshots', (isset($snapshots) ? $snapshots : []));
         $this->view->set('vars', (isset($vars) ? $vars : new stdClass()));
 
         $this->view->setDefaultView('components' . DS . 'modules' . DS . 'vultr' . DS);


### PR DESCRIPTION
Abstracted snapshot and action tabs.
Now pulling snapshots from the API rather than service fields.
Updated snapshots tab to include snapshot status.
Updated actions tab to disable actions while the server is locked.